### PR TITLE
Bring the generic ocdm changes from generic-mediasession branch of OCDM-Widevine repo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,38 +19,67 @@ cmake_minimum_required(VERSION 3.3)
 
 project(Widevine)
 
-find_package(Thunder)
+find_package(WPEFramework)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-set(PLUGIN_NAME Widevine)
-set(MODULE_NAME ${NAMESPACE}${PLUGIN_NAME})
+set(DRM_PLUGIN_NAME Widevine)
+set(MODULE_NAME ${NAMESPACE}${DRM_PLUGIN_NAME})
 
 # This contains all kinds of plugins (publicely available, so they all need the plugin support library !!
 
+find_package(PkgConfig REQUIRED)
 find_package(${NAMESPACE}Core REQUIRED)
-find_package(CompileSettingsDebug REQUIRED)
 find_package(WideVine REQUIRED)
+find_package(OpenSSL REQUIRED)
 
-set(PLUGIN_SOURCES
+if(CMAKE_WIDEVINE_VERSION)
+    message("CMAKE_WIDEVINE_VERSION is ${CMAKE_WIDEVINE_VERSION}")
+    add_definitions(-DWIDEVINE_VERSION=${CMAKE_WIDEVINE_VERSION})
+endif()
+
+set(DRM_PLUGIN_SOURCES
     HostImplementation.cpp
     MediaSession.cpp
     MediaSystem.cpp
     Module.cpp)
 
 # add the library
-add_library(${PLUGIN_NAME} SHARED ${PLUGIN_SOURCES})
-target_compile_definitions(${PLUGIN_NAME} PRIVATE ${WIDEVINE_FLAGS})
-target_include_directories(${PLUGIN_NAME} PRIVATE ${PLUGINS_INCLUDE_DIR} ${WIDEVINE_INCLUDE_DIRS})
-target_link_libraries(${PLUGIN_NAME} 
-    PRIVATE 
-        ${WIDEVINE_LIBRARIES}
-        ${NAMESPACE}Core::${NAMESPACE}Core
-)
+add_library(${DRM_PLUGIN_NAME} SHARED ${DRM_PLUGIN_SOURCES})
 
-set_target_properties(${PLUGIN_NAME} PROPERTIES SUFFIX ".drm")
-set_target_properties(${PLUGIN_NAME} PROPERTIES PREFIX "")
+target_include_directories(${DRM_PLUGIN_NAME}
+    PRIVATE
+        ../widevine/include
+        ../widevine/TATA_include
+        ../widevine/util/include)
 
-install(TARGETS ${PLUGIN_NAME}
-    PERMISSIONS OWNER_READ GROUP_READ
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)
+target_link_libraries(${DRM_PLUGIN_NAME}
+            PRIVATE
+            ${NAMESPACE}Core::${NAMESPACE}Core
+            ${WIDEVINE_LIBRARIES}
+            -lgstsvpext)
+
+if(DEFINED WIDEVINE_REALTEK)
+    target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE liboec_ref_shared.so crypto curl ssl rt pthread)
+    message(STATUS "WIDEVINE_REALTEK is ON")
+elseif(DEFINED WIDEVINE_AMLOGIC)
+    target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE ${OPENSSL_LIBRARIES} curl)
+    message(STATUS "WIDEVINE_AMLOGIC is ON")
+elseif(DEFINED WIDEVINE_BROADCOM)
+    #target_link_libraries(${DRM_PLUGIN_NAME} PRIVATE NEXUS::NEXUS NXCLIENT::NXCLIENT NexusWidevine::NexusWidevine)
+    #message(STATUS "WIDEVINE_BROADCOM is ON")
+endif()
+
+set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES SUFFIX ".drm")
+set_target_properties(${DRM_PLUGIN_NAME} PROPERTIES PREFIX "")
+
+# Enable SVP.
+#if("${RDK_SVP}" STREQUAL "ENABLED")
+    message(STATUS "Using RDK_SVP")
+    add_definitions (-DUSE_SVP)
+    target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${CMAKE_SYSROOT}/usr/include/gstreamer-1.0)
+    target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${CMAKE_SYSROOT}/usr/include/glib-2.0)
+    target_include_directories(${DRM_PLUGIN_NAME} PRIVATE ${CMAKE_SYSROOT}/usr/lib/glib-2.0/include)
+#endif()
+
+install(TARGETS ${DRM_PLUGIN_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/${NAMESPACE}/OCDM)

--- a/HostImplementation.cpp
+++ b/HostImplementation.cpp
@@ -20,7 +20,7 @@
 #include "HostImplementation.h"
 
 using namespace widevine;
-using namespace Thunder;
+using namespace WPEFramework;
 
 namespace CDMi {
 
@@ -44,14 +44,14 @@ void HostImplementation::PreloadFile(const std::string& filename, std::string&& 
 /* virtual */ bool HostImplementation::read(const std::string& name, std::string* data) {
   StorageMap::iterator it = _files.find(name);
   bool ok = it != _files.end();
-  TRACE(Trace::Information, (_T("read file: %s: %s"), name.c_str(), ok ? "ok" : "fail"));
+  TRACE_L1("read file: %s: %s", name.c_str(), ok ? "ok" : "fail");
   if (!ok) return false;
   *data = it->second;
   return true;
 }
 
 /* virtual */ bool HostImplementation::write(const std::string& name, const std::string& data) {
-  TRACE(Trace::Information, (_T("write file: %s"), name.c_str()));
+  TRACE_L1("write file: %s", name.c_str());
   _files[name] = data;
   return true;
 }
@@ -59,12 +59,12 @@ void HostImplementation::PreloadFile(const std::string& filename, std::string&& 
 /* virtual */ bool HostImplementation::exists(const std::string& name) {
   StorageMap::iterator it = _files.find(name);
   bool ok = it != _files.end();
-  TRACE(Trace::Information, (_T("exists? %s: %s"), name.c_str(), ok ? "true" : "false"));
+  TRACE_L1("exists? %s: %s", name.c_str(), ok ? "true" : "false");
   return ok;
 }
 
 /* virtual */ bool HostImplementation::remove(const std::string& name) {
-  TRACE(Trace::Information, (_T("remove: %s"), name.c_str()));
+  TRACE_L1("remove: %s", name.c_str());
   if (name.empty()) {
     // If no name, delete all files (see DeviceFiles::DeleteAllFiles())
     _files.clear();

--- a/HostImplementation.h
+++ b/HostImplementation.h
@@ -17,10 +17,15 @@
  * limitations under the License.
  */
 
-#pragma once
+#ifndef WIDEVINE_HOST_IMPLEMENTATION_H
+#define WIDEVINE_HOST_IMPLEMENTATION_H
 
 #include "Module.h"
 #include "cdm.h"
+
+#include <core/core.h>
+
+#define OVERRIDE override
 
 namespace CDMi {
 
@@ -84,25 +89,27 @@ public:
   //
   // widevine::Cdm::IStorage implementation
   // ---------------------------------------------------------------------------
-  virtual bool read(const std::string& name, std::string* data) override;
-  virtual bool write(const std::string& name, const std::string& data) override;
-  virtual bool exists(const std::string& name) override;
-  virtual bool remove(const std::string& name) override;
-  virtual int32_t size(const std::string& name) override;
-  virtual bool list(std::vector<std::string>* names) override;
+  virtual bool read(const std::string& name, std::string* data) OVERRIDE;
+  virtual bool write(const std::string& name, const std::string& data) OVERRIDE;
+  virtual bool exists(const std::string& name) OVERRIDE;
+  virtual bool remove(const std::string& name) OVERRIDE;
+  virtual int32_t size(const std::string& name) OVERRIDE;
+  virtual bool list(std::vector<std::string>* names) OVERRIDE;
 
   // widevine::Cdm::IClock implementation
   // ---------------------------------------------------------------------------
-  virtual int64_t now() override;
+  virtual int64_t now() OVERRIDE;
 
   // widevine::Cdm::ITimer implementation
   // ---------------------------------------------------------------------------
-  virtual void setTimeout(int64_t delay_ms, IClient* client, void* context) override;
-  virtual void cancel(IClient* client) override;
+  virtual void setTimeout(int64_t delay_ms, IClient* client, void* context) OVERRIDE;
+  virtual void cancel(IClient* client) OVERRIDE;
 
 private:
-  Thunder::Core::TimerType<Timer> _timer;
+  WPEFramework::Core::TimerType<Timer> _timer;
   StorageMap _files;
 };
 
 } // namespace CDMi
+
+#endif  // WIDEVINE_HOST_IMPLEMENTATION_H

--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "Module.h"
 
 #include "MediaSession.h"
@@ -29,13 +30,97 @@
 
 #include <core/core.h>
 
+#include <arpa/inet.h>
+
+#include <curl/curl.h>
+
 #define NYI_KEYSYSTEM "keysystem-placeholder"
 
+//#define DEBUG
+
 using namespace std;
+#define ENT_WV std::cout << "[RDK_LOG:Entering " << __FILE__ << "(" << __LINE__ << "):" << __FUNCTION__ << "]" << endl
+#define EXT_WV std::cout << "[RDK_LOG:Exiting " << __FILE__ << "(" << __LINE__ << "):" << __FUNCTION__ << "]" << endl
 
 namespace CDMi {
 
-Thunder::Core::CriticalSection g_lock;
+// Staging Provisioning Server
+const std::string kCpStagingProvisioningServerUrl =
+    "https://staging-www.sandbox.googleapis.com/"
+    "certificateprovisioning/v1/devicecertificates/create"
+    "?key=AIzaSyB-5OLKTx2iU5mko18DfdwK5611JIjbUhE";
+
+// URL for Google Provisioning Server.
+// The provisioning server supplies the certificate that is needed
+// to communicate with the License Server.
+const std::string kProvisioningServerUrl =
+    "https://www.googleapis.com/"
+    "certificateprovisioning/v1/devicecertificates/create"
+    "?key=AIzaSyB-5OLKTx2iU5mko18DfdwK5611JIjbUhE";
+
+#if defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED
+// NOTE: Provider ID = widevine.com
+const std::string kCpProductionServiceCertificate = wvcdm::a2bs_hex(
+    "0ab9020803121051434fe2a44c763bcc2c826a2d6ef9a718f7d793d005228e02"
+    "3082010a02820101009e27088659dbd9126bc6ed594caf652b0eaab82abb9862"
+    "ada1ee6d2cb5247e94b28973fef5a3e11b57d0b0872c930f351b5694354a8c77"
+    "ed4ee69834d2630372b5331c5710f38bdbb1ec3024cfadb2a8ac94d977d391b7"
+    "d87c20c5c046e9801a9bffaf49a36a9ee6c5163eff5cdb63bfc750cf4a218618"
+    "984e485e23a10f08587ec5d990e9ab0de71460dfc334925f3fb9b55761c61e28"
+    "8398c387a0925b6e4dcaa1b36228d9feff7e789ba6e5ef6cf3d97e6ae05525db"
+    "38f826e829e9b8764c9e2c44530efe6943df4e048c3c5900ca2042c5235dc80d"
+    "443789e734bf8e59a55804030061ed48e7d139b521fbf35524b3000b3e2f6de0"
+    "001f5eeb99e9ec635f02030100013a0c7769646576696e652e636f6d12800332"
+    "2c2f3fedc47f8b7ba88a135a355466e378ed56a6fc29ce21f0cafc7fb253b073"
+    "c55bed253d8650735417aad02afaefbe8d5687902b56a164490d83d590947515"
+    "68860e7200994d322b5de07f82ef98204348a6c2c9619092340eb87df26f63bf"
+    "56c191dc069b80119eb3060d771afaaeb2d30b9da399ef8a41d16f45fd121e09"
+    "a0c5144da8f8eb46652c727225537ad65e2a6a55799909bbfb5f45b5775a1d1e"
+    "ac4e06116c57adfa9ce0672f19b70b876f88e8b9fbc4f96ccc500c676cfb173c"
+    "b6f52601573e2e45af1d9d2a17ef1487348c05cfc6d638ec2cae3fadb655e943"
+    "1330a75d2ceeaa54803e371425111e20248b334a3a50c8eca683c448b8ac402c"
+    "76e6f76e2751fbefb669f05703cec8c64cf7a62908d5fb870375eb0cc96c508e"
+    "26e0c050f3fd3ebe68cef9903ef6405b25fc6e31f93559fcff05657662b3653a"
+    "8598ed5751b38694419242a875d9e00d5a5832933024b934859ec8be78adccbb"
+    "1ec7127ae9afeef9c5cd2e15bd3048e8ce652f7d8c5d595a0323238c598a28");
+#endif /* defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED */
+
+static std::string msgBuffer;
+static size_t curl_writeback(void *ptr, size_t size, size_t nmemb, void *stream)
+{
+    msgBuffer.append((char*)ptr, size * nmemb);
+    return size * nmemb;
+}
+
+static void sendPostRequest(std::string& request, std::string& response);
+
+static void sendPostRequest(std::string& request,
+std::string& response)
+{
+    std::string server_url = kProvisioningServerUrl;
+
+    response.clear();
+
+    msgBuffer.clear();
+    server_url += "&signedRequest=";
+    server_url += request;
+    CURL *curl;
+    CURLcode res;
+    curl = curl_easy_init();
+
+    if (curl) {
+        curl_easy_setopt(curl, CURLOPT_URL, server_url.c_str());
+        curl_easy_setopt(curl, CURLOPT_HTTPPOST, 0);
+        curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curl_writeback);
+        res = curl_easy_perform(curl);
+        response = msgBuffer;
+        curl_easy_cleanup(curl);
+    } else {
+    }
+
+}
+
+WPEFramework::Core::CriticalSection g_lock;
 
 MediaKeySession::MediaKeySession(widevine::Cdm *cdm, int32_t licenseType)
     : m_cdm(cdm)
@@ -43,48 +128,156 @@ MediaKeySession::MediaKeySession(widevine::Cdm *cdm, int32_t licenseType)
     , m_initData("")
     , m_initDataType(widevine::Cdm::kCenc)
     , m_licenseType((widevine::Cdm::SessionType)licenseType)
-    , m_sessionId("") { 
-  ASSERT(m_cdm->isProvisioned());
+    , m_sessionId("")
+    , m_StreamType(Unknown)
+#if defined(USE_SVP)
+    , m_pSVPContext(NULL)
+    , m_rpcID(0)
+#endif
+{
+#if defined(DEBUG)  
+  ENT_WV;
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tGoing to createSession with licenseType: " << m_licenseType << " and sessionId: " << m_sessionId.c_str() << endl;
+#endif
 
-  widevine::Cdm::Status status = m_cdm->createSession(m_licenseType, &m_sessionId);
-
-  if(status != widevine::Cdm::kSuccess){
-    printf("Failed to create a new session: error 0x%04x (%d)\n", status, status);
+  switch ((LicenseType)licenseType) {
+  case PersistentUsageRecord:
+    m_licenseType = widevine::Cdm::kPersistentUsageRecord;
+    break;
+  case PersistentLicense:
+    m_licenseType = widevine::Cdm::kPersistentLicense;
+    break;
+  default:
+    m_licenseType = widevine::Cdm::kTemporary;
+    break;
   }
 
-  ::memset(m_IV, 0 , sizeof(m_IV));
+  widevine::Cdm::Status status =  m_cdm->createSession(m_licenseType, &m_sessionId);
+
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tCreated Session with licenseType: " << m_licenseType << "  and sessionId: " << m_sessionId.c_str() << "  and status is " << status << endl;
+#endif
+
+
+  //TODO: This will be moved to MediaSystem 
+  // Below steps are to done for provisioning when you get the return error "kNeedsDeviceCertificate" (101)
+  // from cdm->createSession() function call
+  if(status == 101) {
+#if defined(DEBUG)
+        cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "Session creation failed with error \"kNeedsDeviceCertificate\" (101)" << endl;
+#endif
+
+#if defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED
+        status = cdm->setServiceCertificate(widevine::Cdm::ServiceRole::kProvisioningService, kCpProductionServiceCertificate);
+#if defined(DEBUG)
+        cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tResult of setServiceCertificate() is: " <<  status << endl;
+#endif
+#endif /* defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED */
+
+        // Generate a provisioning request.
+        std::string request_;
+        status = cdm->getProvisioningRequest(&request_);
+#if defined(DEBUG)
+        cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tResult of getProvisioningRequest() is: " <<  status << endl;
+#endif
+
+        // Getting the provisioning response.
+        std::string response_;
+        sendPostRequest(request_, response_);
+
+        // Handles a provisioning response and provisions the device.
+        status = cdm->handleProvisioningResponse(response_);
+#if defined(DEBUG)
+        cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tResult of handleProvisioningResponse() is: " <<  status << endl;
+#endif
+
+        //Calling createSession.
+        status = m_cdm->createSession(m_licenseType, &m_sessionId);
+#if defined(DEBUG)
+        cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tResult of createSession() is: " <<  status << endl;
+#endif
+  }
+
+  ::memset(m_IV, 0 , sizeof(m_IV));;
+ 
+#ifdef USE_SVP
+  cout << "Initializing SVP context for client side" << endl;
+  gst_svp_ext_get_context(&m_pSVPContext, Client, m_rpcID);
+#endif
+
+#ifdef USE_SVP
+  m_stSecureBuffInfo.bCreateSecureMemRegion = true;
+  m_stSecureBuffInfo.SecureMemRegionSize = 512 * 1024;
+
+  if( 0 != svp_allocate_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, nullptr, m_stSecureBuffInfo.SecureMemRegionSize))
+  {
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tsecure memory, allocate failed " << endl;
+#endif
+  }
+#endif
+
+#if defined(DEBUG) 
+  EXT_WV;
+#endif
 }
 
 MediaKeySession::~MediaKeySession(void) {
+  Close();
+#ifdef USE_SVP
+  gst_svp_ext_free_context(m_pSVPContext);
+#endif
 }
 
 
 void MediaKeySession::Run(const IMediaKeySessionCallback *f_piMediaKeySessionCallback) {
 
+#if defined(DEBUG)
+  ENT_WV;
+#endif
+
   if (f_piMediaKeySessionCallback) {
     m_piCallback = const_cast<IMediaKeySessionCallback*>(f_piMediaKeySessionCallback);
 
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tCalling generateRequest() with \tSessionId: " << m_sessionId.c_str() << "\tInitDataType: " << m_initDataType << "\tInitData: " << m_initData << endl;
+#endif
+
     widevine::Cdm::Status status = m_cdm->generateRequest(m_sessionId, m_initDataType, m_initData);
+
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tStatus of generateRequest: " << status << endl;
+#endif
+
     if (widevine::Cdm::kSuccess != status) {
        printf("generateRequest failed\n");
-       m_piCallback->OnKeyMessage((const uint8_t *) "", 0, "");
+       m_piCallback->OnError(0, CDMi_S_FALSE, "generateRequest");
     }
   }
   else {
       m_piCallback = nullptr;
   }
+#if defined(DEBUG)
+  EXT_WV;
+#endif
 }
 
 void MediaKeySession::onMessage(widevine::Cdm::MessageType f_messageType, const std::string& f_message) {
+#if defined(DEBUG)
+  ENT_WV;
+#endif
   std::string destUrl;
   std::string message;
-
+ 
   switch (f_messageType) {
   case widevine::Cdm::kLicenseRequest:
   case widevine::Cdm::kLicenseRenewal:
   case widevine::Cdm::kLicenseRelease:
   {
-    destUrl.assign(kLicenseServer); 
+    destUrl.assign(kLicenseServer);   
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tDestUrl: " << destUrl.c_str() << endl;
+#endif
 
     // FIXME: Errrr, this is weird.
     //if ((Cdm::MessageType)f_message[1] == (Cdm::kIndividualizationRequest + 1)) {
@@ -92,6 +285,9 @@ void MediaKeySession::onMessage(widevine::Cdm::MessageType f_messageType, const 
     //  messageType = Cdm::kIndividualizationRequest;
     //}
     
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tMessage Type: " << f_messageType << endl;
+#endif
     message = std::to_string(f_messageType) + ":Type:";
     break;
   }
@@ -100,31 +296,56 @@ void MediaKeySession::onMessage(widevine::Cdm::MessageType f_messageType, const 
     break;
   }
   message.append(f_message.c_str(),  f_message.size());
+
   m_piCallback->OnKeyMessage((const uint8_t*) message.c_str(), message.size(), (char*) destUrl.c_str());
+#if defined(DEBUG)
+  EXT_WV;
+#endif
 }
 
 static const char* widevineKeyStatusToCString(widevine::Cdm::KeyStatus widevineStatus)
 {
     switch (widevineStatus) {
     case widevine::Cdm::kUsable:
+#if defined(DEBUG)
+ 	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey Usable" << endl;
+#endif
         return "KeyUsable";
         break;
     case widevine::Cdm::kExpired:
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey Expired" << endl;
+#endif
         return "KeyExpired";
         break;
     case widevine::Cdm::kOutputRestricted:
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey OutputRestricted" << endl;
+#endif
         return "KeyOutputRestricted";
         break;
     case widevine::Cdm::kStatusPending:
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey StatusPending" << endl;
+#endif
         return "KeyStatusPending";
         break;
     case widevine::Cdm::kInternalError:
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey InternalError" << endl;
+#endif
         return "KeyInternalError";
         break;
-    case widevine::Cdm::kReleased:
+    case widevine::Cdm::kReleased:	
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey Released" << endl;
+#endif
         return "KeyReleased";
         break;
-    default:
+    default:	
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tUnknownError" << endl;
+#endif
         return "UnknownError";
         break;
     }
@@ -132,9 +353,16 @@ static const char* widevineKeyStatusToCString(widevine::Cdm::KeyStatus widevineS
 
 void MediaKeySession::onKeyStatusChange()
 {
+#if defined(DEBUG)
+    ENT_WV;
+#endif
     widevine::Cdm::KeyStatusMap map;
-    if (widevine::Cdm::kSuccess != m_cdm->getKeyStatuses(m_sessionId, &map))
+    if (widevine::Cdm::kSuccess != m_cdm->getKeyStatuses(m_sessionId, &map)) {
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tInside if 'widevine::Cdm::kSuccess != m_cdm->getKeyStatuses(m_sessionId, &map)'" << endl;	
+#endif
         return;
+    }
 
     for (const auto& pair : map) {
         const std::string& keyValue = pair.first;
@@ -145,30 +373,54 @@ void MediaKeySession::onKeyStatusChange()
                                         keyValue.length());
     }
     m_piCallback->OnKeyStatusesUpdated();
+#if defined(DEBUG)
+    EXT_WV;
+#endif
 }
 
 void MediaKeySession::onKeyStatusError(widevine::Cdm::Status status) {
   std::string errorStatus;
   switch (status) {
   case widevine::Cdm::kNeedsDeviceCertificate:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tNeeds DeviceCertificate" << endl;
+#endif
     errorStatus = "NeedsDeviceCertificate";
     break;
   case widevine::Cdm::kSessionNotFound:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tSessionNotFound" << endl;
+#endif
     errorStatus = "SessionNotFound";
     break;
   case widevine::Cdm::kDecryptError:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tDecryptError" << endl;
+#endif
     errorStatus = "DecryptError";
     break;
   case widevine::Cdm::kTypeError:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tTypeError" << endl;
+#endif
     errorStatus = "TypeError";
     break;
   case widevine::Cdm::kQuotaExceeded:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tQuotaExceeded" << endl;
+#endif
     errorStatus = "QuotaExceeded";
     break;
   case widevine::Cdm::kNotSupported:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tNotSupported" << endl;
+#endif
     errorStatus = "NotSupported";
     break;
   default:
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tUnExpected Error" << endl;
+#endif
     errorStatus = "UnExpectedError";
     break;
   }
@@ -176,6 +428,9 @@ void MediaKeySession::onKeyStatusError(widevine::Cdm::Status status) {
 }
 
 void MediaKeySession::onRemoveComplete() {
+#if defined(DEBUG)
+    ENT_WV;
+#endif
     widevine::Cdm::KeyStatusMap map;
     if (widevine::Cdm::kSuccess == m_cdm->getKeyStatuses(m_sessionId, &map)) {
         for (const auto& pair : map) {
@@ -187,6 +442,9 @@ void MediaKeySession::onRemoveComplete() {
         }
         m_piCallback->OnKeyStatusesUpdated();
     }
+#if defined(DEBUG)
+    EXT_WV;
+#endif
 }
 
 void MediaKeySession::onDeferredComplete(widevine::Cdm::Status) {
@@ -196,57 +454,135 @@ void MediaKeySession::onDirectIndividualizationRequest(const string&) {
 }
 
 CDMi_RESULT MediaKeySession::Load(void) {
+
+#if defined(DEBUG)
+  ENT_WV;
+#endif
+
   CDMi_RESULT ret = CDMi_S_FALSE;
   g_lock.Lock();
   widevine::Cdm::Status status = m_cdm->load(m_sessionId);
-  if (widevine::Cdm::kSuccess != status)
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tstatus: " << status << endl;
+#endif
+  if (widevine::Cdm::kSuccess != status) {
     onKeyStatusError(status);
-  else
+  }else {
     ret = CDMi_SUCCESS;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tLoad SUCCESS: " << ret << endl;
+#endif
+  }
   g_lock.Unlock();
+
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tresult: " << ret << endl;
+  EXT_WV;
+#endif
   return ret;
 }
 
 void MediaKeySession::Update(
     const uint8_t *f_pbKeyMessageResponse,
     uint32_t f_cbKeyMessageResponse) {
+
+#if defined(DEBUG)
+  ENT_WV;
+#endif
+  widevine::Cdm::Status ret = widevine::Cdm::kSuccess;
   std::string keyResponse(reinterpret_cast<const char*>(f_pbKeyMessageResponse),
       f_cbKeyMessageResponse);
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKey Response: " << keyResponse.c_str() << endl;
+#endif
   g_lock.Lock();
-  widevine::Cdm::Status status = m_cdm->update(m_sessionId, keyResponse);
-  if (widevine::Cdm::kSuccess == status)
-     onKeyStatusChange();
-  else
-     onKeyStatusError(status);
+  if (widevine::Cdm::kSuccess != (ret = m_cdm->update(m_sessionId, keyResponse))) {
+      onKeyStatusError(ret);
+  }
+  onKeyStatusChange();
   g_lock.Unlock();
+#if defined(DEBUG)
+  EXT_WV;
+#endif
 }
 
 CDMi_RESULT MediaKeySession::Remove(void) {
+
+#if defined(DEBUG)
+  ENT_WV;
+#endif
   CDMi_RESULT ret = CDMi_S_FALSE;
   g_lock.Lock();
   widevine::Cdm::Status status = m_cdm->remove(m_sessionId);
-  if (widevine::Cdm::kSuccess != status)
+
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tstatus: " << status << endl;
+#endif
+  if (widevine::Cdm::kSuccess != status) {
     onKeyStatusError(status);
-  else
+  }else {
     ret =  CDMi_SUCCESS;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tRemove SUCCESS: " << ret << endl;
+#endif
+  }
   g_lock.Unlock();
+
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tresult: " << ret << endl;
+  EXT_WV;
+#endif
   return ret;
 }
 
 CDMi_RESULT MediaKeySession::Close(void) {
+#if defined(DEBUG)
+  ENT_WV;
+#endif
   CDMi_RESULT status = CDMi_S_FALSE;
+
+#if defined(USE_SVP)
+  m_stSecureBuffInfo.bReleaseSecureMemRegion = true;
+  if(0 != svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0))
+  {
+      fprintf(stderr, "[%s:%d]  secure memory, free failed",__FUNCTION__,__LINE__);
+  }
+  else {
+      m_stSecureBuffInfo.bCreateSecureMemRegion = false;
+      m_stSecureBuffInfo.SecureMemRegionSize = 0;
+  }
+#endif
+
   g_lock.Lock();
-  if (widevine::Cdm::kSuccess == m_cdm->close(m_sessionId))
+  if (widevine::Cdm::kSuccess == m_cdm->close(m_sessionId)) {
     status = CDMi_SUCCESS;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tClose SUCCESS: " << status << endl;
+#endif
+  }
   g_lock.Unlock();
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tstatus: " << status << endl;
+  EXT_WV;
+#endif
   return status;
 }
 
 const char* MediaKeySession::GetSessionId(void) const {
+#if defined(DEBUG)
+  ENT_WV;
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tSessionId: " << m_sessionId.c_str() << endl;
+  EXT_WV;
+#endif
   return m_sessionId.c_str();
 }
 
 const char* MediaKeySession::GetKeySystem(void) const {
+#if defined(DEBUG)
+  ENT_WV;
+  cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tKeySystem: " << NYI_KEYSYSTEM << endl;
+  EXT_WV;
+#endif
   return NYI_KEYSYSTEM;//TODO: replace with keysystem and test
 }
 
@@ -257,15 +593,27 @@ CDMi_RESULT MediaKeySession::Init(
     uint32_t f_cbInitData,
     const uint8_t *f_pbCDMData,
     uint32_t f_cbCDMData) {
+#if defined(DEBUG)
+  ENT_WV;
+#endif
   switch ((LicenseType)licenseType) {
   case PersistentUsageRecord:
     m_licenseType = widevine::Cdm::kPersistentUsageRecord;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tPersistentUsageRecord: " << m_licenseType <<endl;
+#endif
     break;
   case PersistentLicense:
     m_licenseType = widevine::Cdm::kPersistentLicense;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tPersistentLicense: " << m_licenseType<<endl;
+#endif
     break;
   default:
     m_licenseType = widevine::Cdm::kTemporary;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tTemporary: " << m_licenseType << endl;
+#endif
     break;
   }
 
@@ -281,96 +629,318 @@ CDMi_RESULT MediaKeySession::Init(
 
   if (f_pbCDMData && f_cbCDMData)
     m_CDMData.assign((const char*) f_pbCDMData, f_cbCDMData);
+#if defined(DEBUG)
+  EXT_WV;
+#endif
   return CDMi_SUCCESS;
 }
 
+CDMi_RESULT MediaKeySession::SetParameter(const std::string& name, const std::string& value)
+{
+  CDMi_RESULT retVal = CDMi_S_FALSE;
+
+  if(name.find("mediaType") != std::string::npos) {
+    if(value.find("video") != std::string::npos) {
+      // Found a video mime type
+      m_StreamType = Video;
+      retVal = CDMi_SUCCESS;
+    }
+    else if(value.find("audio") != std::string::npos) {
+      // Found a audio mime type
+      m_StreamType = Audio;
+      retVal = CDMi_SUCCESS;
+    }
+  }
+
+  if(name.find("RESOLUTION") != std::string::npos) {
+
+    if (m_cdm != nullptr)
+    {
+      uint32_t videoWidth;
+      uint32_t videoHeight;
+      sscanf(value.c_str(), "%d,%d", &videoWidth, &videoHeight);
+      m_cdm->setVideoResolution(m_sessionId, videoWidth, videoHeight);
+    }
+    else
+    {
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] m_cdm is NULL" << endl;
+#endif
+    }
+  }
+
+  if(name.find("rpcId") != std::string::npos) {
+
+    // Got the RPC ID for gst-svp-ext communication
+    unsigned int nID = 0;
+    nID =  (unsigned int)std::stoul(value.c_str(), nullptr, 16);
+    if(nID != 0) {
+#ifdef USE_SVP
+      //fprintf(stderr, "Initializing SVP context for client side ID = %X\n", nID);
+      gst_svp_ext_get_context(&m_pSVPContext, Client, nID);
+#endif
+    }
+  }
+
+  return retVal;
+}
+
 CDMi_RESULT MediaKeySession::Decrypt(
-    const uint8_t *f_pbSessionKey VARIABLE_IS_NOT_USED,
-    uint32_t f_cbSessionKey VARIABLE_IS_NOT_USED,
-    const EncryptionScheme encryptionScheme,
-    const EncryptionPattern& pattern,
-    const uint8_t *f_pbIV,
-    uint32_t f_cbIV,
-    uint8_t *f_pbData,
-    uint32_t f_cbData,
-    uint32_t *f_pcbOpaqueClearContent,
-    uint8_t **f_ppbOpaqueClearContent,
-    const uint8_t keyIdLength,
-    const uint8_t* keyId,
-    bool /* initWithLast15 */)
+        uint8_t*                 inData,          // Incoming encrypted data
+        const uint32_t           inDataLength,    // Incoming encrypted data length
+        uint8_t**                outData,         // Outgoing decrypted data
+        uint32_t*                outDataLength,   // Outgoing decrypted data length
+        const SampleInfo*        sampleInfo,      // Information required to decrypt Sample
+        const IStreamProperties* properties)
 {
   g_lock.Lock();
   widevine::Cdm::KeyStatusMap map;
   std::string keyStatus;
 
+  void *pEncryptedDataStart  = nullptr;
+  widevine::Cdm::Subsample subsamplesInfo[ 2 ];
   CDMi_RESULT status = CDMi_S_FALSE;
-  *f_pcbOpaqueClearContent = 0;
+  *outDataLength = 0;
+  unsigned char iv[16];
+  /* by default SVP is enabled for both A/V */
+  bool useSVP = true;
+  bool bIsDynamicSVPEncEnabled = false;
+  void *DstPhys = NULL;
 
-  memcpy(m_IV, f_pbIV, (f_cbIV > 16 ? 16 : f_cbIV));
-  if (f_cbIV < 16) {
-    memset(&(m_IV[f_cbIV]), 0, 16 - f_cbIV);
+  void * header = NULL;
+  void* secToken = NULL;
+
+#ifdef USE_SVP
+  bIsDynamicSVPEncEnabled = svpIsDynamicSVPEncEnabled();
+  if (bIsDynamicSVPEncEnabled)
+  {
+    /* Dynamic SVP supported means, SVP is enabled for Video only */
+    if (properties->GetMediaType() != Video) {
+      useSVP = false;
+    }
   }
+#endif
+
+  memset(iv,0,16);
+  memcpy(iv,(char*)sampleInfo->iv, sampleInfo->ivLength);
 
   if (widevine::Cdm::kSuccess == m_cdm->getKeyStatuses(m_sessionId, &map)) {
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] m_cdm->getKeyStatuses is SUCCESS" << endl;
+#endif
     widevine::Cdm::KeyStatusMap::iterator it;
-    if(keyIdLength > 0) {
+    if(sampleInfo->keyIdLength > 0) {
       // if keyid is provided, find it in the map
-      std::string keyIdString((const char*) keyId, (size_t) keyIdLength);
+      std::string keyIdString((const char*) sampleInfo->keyId, (size_t) sampleInfo->keyIdLength);
+#if defined(DEBUG)
+      cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] KeyIdString: " << keyIdString.c_str() << endl;
+#endif
       it = map.find(keyIdString);
     } else {
       // if no keyid is provided, use the first one in the map
+#if defined(DEBUG)
+      cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] keyid is not provided" << endl;
+#endif
       it = map.begin();
     }
 
     // FIXME: We just check the first key? How do we know that's the Widevine key and not, say, a PlayReady one?
     if (widevine::Cdm::kUsable == it->second) {
-      // Decrypt content in place of input buffer. 
-      widevine::Cdm::OutputBuffer output;
-      output.data = const_cast<uint8_t*>(f_pbData);
-      output.data_length = f_cbData;
+	    // Here we will sepreate each of these to create the decryptSample
+	    widevine::Cdm::Sample decryptSample;
+	    uint32_t actualEncDataLength = 0;
 
-      widevine::Cdm::InputBuffer input;
-      input.data = f_pbData;
-      input.data_length = f_cbData;
-      input.key_id = reinterpret_cast<const uint8_t*>((it->first).c_str());
-      input.key_id_length = (it->first).size();
-      input.iv = m_IV;
-      input.iv_length = sizeof(m_IV);
-      input.pattern.encrypted_blocks = pattern.encrypted_blocks;
-      input.pattern.clear_blocks = pattern.clear_blocks;
-      switch (encryptionScheme) {
-          case AesCtr_Cenc:
-          case AesCtr_Cens:
-              input.encryption_scheme = widevine::Cdm::kAesCtr;
-              break;
-          case AesCbc_Cbc1:
-          case AesCbc_Cbcs:
-              input.encryption_scheme = widevine::Cdm::kAesCbc;
-              break;
-          default:
-              input.encryption_scheme = widevine::Cdm::kClear;
-              break;
+  if (gst_svp_has_header(m_pSVPContext, inData))
+  {
+    header = (void*)inData;
+    pEncryptedDataStart = reinterpret_cast<uint8_t *>(gst_svp_header_get_start_of_data(m_pSVPContext, header));
+    gst_svp_header_get_field(m_pSVPContext, header, SvpHeaderFieldName::DataSize, &actualEncDataLength);
+  }
+
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] actualEncDataLength: " << actualEncDataLength << endl;
+#endif
+
+#ifdef USE_SVP
+
+  if (useSVP) {
+
+    // Reallocate input memory if needed.
+    if(m_stSecureBuffInfo.bCreateSecureMemRegion)
+    {
+      if (actualEncDataLength >  m_stSecureBuffInfo.SecureMemRegionSize) {
+          m_stSecureBuffInfo.bReleaseSecureMemRegion = true;
+          if(0 != svp_release_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, nullptr, 0))
+          {
+              fprintf(stderr, "[%s:%d]  Secure memory free falied",__FUNCTION__,__LINE__);
+              goto ErrorExit;
+          }
+          m_stSecureBuffInfo.SecureMemRegionSize = actualEncDataLength;
+          m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
+          m_stSecureBuffInfo.bCreateSecureMemRegion = true;
+
+          if(0 != svp_allocate_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, nullptr, m_stSecureBuffInfo.SecureMemRegionSize))
+          {
+              fprintf(stderr, "[%s:%d] Secure memory, re-allocation failed %d",__FUNCTION__,__LINE__, m_stSecureBuffInfo.SecureMemRegionSize);
+              goto ErrorExit;
+          }
       }
-      if (widevine::Cdm::kSuccess == m_cdm->decrypt(input, output)) {
-        // Return decrypted content in place of the input buffer.
-        *f_ppbOpaqueClearContent = const_cast<uint8_t*>(f_pbData);
-        *f_pcbOpaqueClearContent = f_cbData;
-        status = CDMi_SUCCESS;
+    }
+
+    m_stSecureBuffInfo.patternClearBlocks = sampleInfo->pattern.clear_blocks;
+
+    if(0 != svp_allocate_secure_buffers(m_pSVPContext, (void**)&m_stSecureBuffInfo, nullptr, (uint8_t*)pEncryptedDataStart, actualEncDataLength))
+    {
+        fprintf(stderr, "[%s:%d]  secure memory, allocate failed [%d]",__FUNCTION__,__LINE__, actualEncDataLength);
+        goto ErrorExit;
+    }
+
+    svp_buffer_alloc_token(&secToken);
+    svp_buffer_to_token(m_pSVPContext, (void *)&m_stSecureBuffInfo, secToken);
+  }
+
+#endif
+
+#if defined(DEBUG)
+ 	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] subSampleCount: " << sampleInfo->subSampleCount << endl;
+#endif
+            if (useSVP)
+              decryptSample.input.data = static_cast<const uint8_t*>( m_stSecureBuffInfo.pEncryptedDataBuffer );
+            else 
+	      decryptSample.input.data = static_cast<const uint8_t*>( pEncryptedDataStart );
+
+	    decryptSample.input.data_length = actualEncDataLength;
+	    decryptSample.input.iv = iv;
+	    decryptSample.input.iv_length = sizeof(iv);
+
+      if (sampleInfo->subSampleCount != 0 ) {
+        decryptSample.input.subsamples = (const widevine::Cdm::Subsample*) sampleInfo->subSample;
+	      decryptSample.input.subsamples_length = sampleInfo->subSampleCount;
+      } else{
+        memset( subsamplesInfo, 0, sizeof( subsamplesInfo ) );
+        subsamplesInfo[ 0 ].clear_bytes = 0;
+        subsamplesInfo[ 0 ].protected_bytes = actualEncDataLength;
+
+        decryptSample.input.subsamples = (const widevine::Cdm::Subsample*) subsamplesInfo;
+        decryptSample.input.subsamples_length = 1;
       }
+
+	    if (useSVP)
+		    decryptSample.output.data = m_stSecureBuffInfo.pPhysAddr;
+	    else
+		    decryptSample.output.data = pEncryptedDataStart;
+
+	    decryptSample.output.data_offset = 0;
+	    decryptSample.output.data_length = actualEncDataLength;
+
+	    widevine::Cdm::DecryptionBatch decryptionBatch;
+	    decryptionBatch.key_id = sampleInfo->keyId;
+	    decryptionBatch.key_id_length = sampleInfo->keyIdLength;
+	    decryptionBatch.samples = &decryptSample;
+	    decryptionBatch.samples_length = 1;
+	    decryptionBatch.pattern.encrypted_blocks = sampleInfo->pattern.encrypted_blocks;
+	    decryptionBatch.pattern.clear_blocks = sampleInfo->pattern.clear_blocks;
+	    if (useSVP) {
+		    decryptionBatch.is_secure = true;
+		    decryptionBatch.is_video = true;
+	    } else {
+		    decryptionBatch.is_secure = false;
+		    decryptionBatch.is_video = false;
+	    }
+
+	    switch (sampleInfo->scheme) {
+            case AesCtr_Cenc:
+            case AesCtr_Cens:
+		    //case 0:
+			    decryptionBatch.encryption_scheme = widevine::Cdm::kAesCtr;
+#if defined(DEBUG)
+			    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] Inside kAesCtr" << endl;
+#endif
+			    break;
+            case AesCbc_Cbc1:
+            case AesCbc_Cbcs:
+		    //case 1:
+			    decryptionBatch.encryption_scheme = widevine::Cdm::kAesCbc;
+#if defined(DEBUG)
+			    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] Inside kAesCbc" << endl;
+#endif
+			    break;
+	    }
+
+	    if (widevine::Cdm::kSuccess == m_cdm->decrypt(m_sessionId, decryptionBatch)) {
+
+        if (useSVP) {
+#ifdef USE_SVP
+
+          if (header)
+          {
+            gst_svp_header_set_field(m_pSVPContext, header, SvpHeaderFieldName::Type, TokenType::Handle);
+          }
+          memcpy((uint8_t *)pEncryptedDataStart, secToken, svp_token_size());
+          svp_buffer_free_token(secToken);
+          //TODO: note the return token data and size
+#endif
+          *outData = const_cast<uint8_t*>(inData);
+          *outDataLength = inDataLength;
+        } else{
+          // Add a header to the output buffer.
+          if (header)
+          {
+            gst_svp_header_set_field(m_pSVPContext, header, SvpHeaderFieldName::Type, TokenType::InPlace);
+          }
+		    } 
+
+		    status = CDMi_SUCCESS;
+#if defined(DEBUG)
+		    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] decryption success..! and status: " << status << endl;
+#endif
+	    }else{
+		    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] decryption failed..!" << endl;
+#ifdef USE_SVP
+      if (useSVP)
+      {
+        m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
+        // Free decrypted secure buffer.
+        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, m_stSecureBuffInfo.pAVSecBuffer , nullptr, 0);
+      }
+#endif
+	    }
+
     }
   }
 
   g_lock.Unlock();
+#if defined(DEBUG)
+  cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] status: " << status << endl;
+  EXT_WV;
+#endif
+
+ErrorExit:
   return status;
 }
 
 CDMi_RESULT MediaKeySession::ReleaseClearContent(
-    const uint8_t *f_pbSessionKey VARIABLE_IS_NOT_USED,
-    uint32_t f_cbSessionKey VARIABLE_IS_NOT_USED,
-    const uint32_t  f_cbClearContentOpaque VARIABLE_IS_NOT_USED,
-    uint8_t  *f_pbClearContentOpaque VARIABLE_IS_NOT_USED) {
-  //There is nothing to free due to in-place decryption
-  return CDMi_SUCCESS;
+    const uint8_t *f_pbSessionKey,
+    uint32_t f_cbSessionKey,
+    const uint32_t  f_cbClearContentOpaque,
+    uint8_t  *f_pbClearContentOpaque ){
+#if defined(DEBUG)
+  ENT_WV;
+#endif
+
+  CDMi_RESULT ret = CDMi_S_FALSE;
+  if (f_pbClearContentOpaque) {
+    free(f_pbClearContentOpaque);
+    ret = CDMi_SUCCESS;
+#if defined(DEBUG)
+    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "]ReleaseClearContent SUCCESS: " << ret <<endl;
+#endif
+  }
+
+#if defined(DEBUG)
+  EXT_WV;
+#endif
+  return ret;
 }
 
 }  // namespace CDMi

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -23,14 +23,49 @@
 #include <iostream>
 #include <sstream>
 #include <sys/utsname.h>
-
 #include <core/core.h>
-#include <plugins/Types.h>
 
-using namespace Thunder;
+//#define DEBUG
+
+using namespace std;
+#define ENT_WV std::cout << "[RDK_LOG]Entering " << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << endl
+#define EXT_WV std::cout << "[RDK_LOG]Exiting " << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << endl
+
+using namespace WPEFramework;
 
 namespace CDMi {
-class WideVine : public IMediaKeys, public widevine::Cdm::IEventListener
+
+std::string ReadFromPropertiesFile(const char* prefix, size_t prefix_len) {
+    FILE* properties = fopen("/etc/device.properties", "r");
+    if (!properties) {
+        return "";
+    }
+
+    char* buffer = nullptr;
+    size_t size = 0;
+    char* out_value = nullptr;
+
+    while (getline(&buffer, &size, properties) != -1) {
+        if (strncmp(prefix, buffer, prefix_len) == 0) {
+            char* remainder = buffer + prefix_len;
+            size_t remainder_length = strlen(remainder);
+            if (remainder_length > 1) {
+                // trim the newline character
+                for(int i = remainder_length - 1; i >= 0 && !std::isalnum(remainder[i]); --i)
+                    remainder[i] = '\0';
+                free(buffer);
+                fclose(properties);
+                return remainder;
+            }
+        }
+    }
+
+    free(buffer);
+    fclose(properties);
+    return "";
+}
+
+class WideVine : public IMediaKeys, public widevine::Cdm::IEventListener, public IMediaSystemMetrics
 {
 private:
     WideVine (const WideVine&) = delete;
@@ -52,7 +87,6 @@ private:
             , Company()
             , Model()
             , Device()
-            , StorageLocation()
         {
             Add(_T("certificate"), &Certificate);
             Add(_T("keybox"), &Keybox);
@@ -60,7 +94,6 @@ private:
             Add(_T("company"), &Company);
             Add(_T("model"), &Model);
             Add(_T("device"), &Device);
-            Add(_T("storagelocation"), &StorageLocation);
         }
         ~Config()
         {
@@ -73,7 +106,6 @@ private:
         Core::JSON::String Company;
         Core::JSON::String Model;
         Core::JSON::String Device;
-        Core::JSON::String StorageLocation;
     };
 
 public:
@@ -84,6 +116,9 @@ public:
         , _sessions() {
     }
     virtual ~WideVine() {
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         _adminLock.Lock();
 
         SessionMap::iterator index (_sessions.begin());
@@ -100,11 +135,19 @@ public:
         if (_cdm != nullptr) {
             delete _cdm;
         }
+#if defined(DEBUG)
+	EXT_WV;
+#endif
     }
 
-    void Initialize(const Thunder::PluginHost::IShell* shell, const std::string& configline)
+    void Initialize(const WPEFramework::PluginHost::IShell * shell, const std::string& configline)
     {
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         widevine::Cdm::ClientInfo client_info;
+
+        svpPlatformInitializeWidevine();
 
         Config config;
         config.FromString(configline);
@@ -112,19 +155,23 @@ public:
         if (config.Product.IsSet() == true) {
             client_info.product_name = config.Product.Value();
         } else {
-            client_info.product_name = "Thunder";
+            client_info.product_name = "WPEFramework";
         }
 
         if (config.Company.IsSet() == true) {
             client_info.company_name = config.Company.Value();
         } else {
-            client_info.company_name = "www.metrological.com";
+	    const char kPrefixStr[] = "OPERATOR_NAME=";
+            const size_t kPrefixStrLength = sizeof(kPrefixStr) / sizeof(kPrefixStr[0]) - 1;
+            client_info.company_name = ReadFromPropertiesFile(kPrefixStr, kPrefixStrLength);
         }
 
         if (config.Model.IsSet() == true) {
             client_info.model_name = config.Model.Value();
         } else {
-            client_info.model_name = "reference";
+	    const char kPrefixStr[] = "MODEL_NUM=";
+            const size_t kPrefixStrLength = sizeof(kPrefixStr) / sizeof(kPrefixStr[0]) - 1;
+            client_info.model_name = ReadFromPropertiesFile(kPrefixStr, kPrefixStrLength);
         }
 
 #if defined(__linux__)
@@ -140,7 +187,9 @@ public:
             }
         }
 #else
-        client_info.device_name = "Unknown";
+	const char kPrefixStr[] = "DEVICE_NAME=";
+        const size_t kPrefixStrLength = sizeof(kPrefixStr) / sizeof(kPrefixStr[0]) - 1;
+        client_info.device_name = ReadFromPropertiesFile(kPrefixStr, kPrefixStrLength);
 #endif
         client_info.build_info = __DATE__;
 
@@ -148,46 +197,39 @@ public:
             Core::SystemInfo::SetEnvironment("WIDEVINE_KEYBOX_PATH", config.Keybox.Value().c_str());
         }
 
-        if (config.StorageLocation.IsSet() == true) {
-            Core::SystemInfo::SetEnvironment("WIDEVINE_STORAGE_PATH", config.StorageLocation.Value().c_str());
-        }
-
-        if ((config.Certificate.IsSet() == true) && (config.Certificate.Value().empty() == false)) {
-
-            ASSERT(shell != nullptr);
-
-	    PluginHost::ISubSystem* subsystem = const_cast<Thunder::PluginHost::IShell*>(shell)->SubSystems();
-
-            ASSERT(subsystem != nullptr);
-
-            string storage;
-
-            if ((subsystem != nullptr) && (config.Certificate.Value()[0] != '/')) {
-                const PluginHost::ISubSystem::IProvisioning* provisioning(subsystem->Get<PluginHost::ISubSystem::IProvisioning>());
-                
-                if (provisioning != nullptr) {
-                    storage = provisioning->Storage();
-                    provisioning->Release();
-                }
-                subsystem->Release();
-            }
-
-            TRACE(Trace::Information, (_T("loading certificate is set to: \'%s\'\n"), string(storage + config.Certificate.Value()).c_str()));
-
-            Core::DataElementFile dataBuffer(storage + config.Certificate.Value(), Core::File::USER_READ);
+        if (config.Certificate.IsSet() == true) {
+            Core::DataElementFile dataBuffer(config.Certificate.Value(), Core::File::USER_READ);
 
             if(dataBuffer.IsValid() == false) {
-                TRACE(Trace::Warning, (_T("Failed to open %s"), config.Certificate.Value().c_str()));
+                TRACE_L1(_T("Failed to open %s"), config.Certificate.Value().c_str());
             } else {
                 _host.PreloadFile(_certificateFilename,  std::string(reinterpret_cast<const char*>(dataBuffer.Buffer()), dataBuffer.Size()));
             }
         }
 
         if (widevine::Cdm::kSuccess == widevine::Cdm::initialize(
-                widevine::Cdm::kNoSecureOutput, client_info, &_host,
+                widevine::Cdm::kOpaqueHandle, client_info, &_host,
                 &_host, &_host, static_cast<widevine::Cdm::LogLevel>(0))) {
             _cdm = widevine::Cdm::create(this, &_host, false);
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] widevine cdm version is: " << _cdm->version << endl;
+#endif
         }
+
+        const char kPrefixStr[] = "COBALT_CERT_SCOPE=";
+        const size_t kPrefixStrLength = sizeof(kPrefixStr) / sizeof(kPrefixStr[0]) - 1;
+        if (widevine::Cdm::kSuccess == _cdm->setAppParameter("youtube_cert_scope", ReadFromPropertiesFile(kPrefixStr, kPrefixStrLength))) {
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] setAppParameter youtube_cert_scope SUCCESS..!" << endl;
+#endif
+        }
+        else {
+        cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] setAppParameter youtube_cert_scope failed..!" << endl;
+	}
+
+#if defined(DEBUG)
+	EXT_WV;
+#endif
     }
 
     virtual CDMi_RESULT CreateMediaKeySession(
@@ -200,9 +242,16 @@ public:
         uint32_t f_cbCDMData,
         IMediaKeySession **f_ppiMediaKeySession) {
 
+#if defined(DEBUG)
+	ENT_WV;
+#endif
+
         CDMi_RESULT dr = CDMi_S_FALSE;
         *f_ppiMediaKeySession = nullptr;
 
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] creating a mediaKeySession with\tcdm: " << _cdm << "\tlicenseType: " << licenseType << endl;
+#endif
         MediaKeySession* mediaKeySession = new MediaKeySession(_cdm, licenseType);
 
         dr = mediaKeySession->Init(licenseType,
@@ -214,14 +263,24 @@ public:
 
 
         if (dr != CDMi_SUCCESS) {
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] as result of mediaKeySession->Init() is not success, deleting mediaKeySession" << endl;
+#endif
             delete mediaKeySession;
         }
         else {
             std::string sessionId (mediaKeySession->GetSessionId());
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] mediaKeySession->Init is SUCCESS and value of sessionId: " << sessionId.c_str() << endl;
+#endif
             _sessions.insert(std::pair<std::string, MediaKeySession*>(sessionId, mediaKeySession));
             *f_ppiMediaKeySession = mediaKeySession;
         }
 
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] result: " << dr << endl;
+	EXT_WV;
+#endif
         return dr;
     }
 
@@ -229,18 +288,60 @@ public:
         const uint8_t *f_pbServerCertificate,
         uint32_t f_cbServerCertificate) {
 
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         CDMi_RESULT dr = CDMi_S_FALSE;
 
         std::string serverCertificate(reinterpret_cast<const char*>(f_pbServerCertificate), f_cbServerCertificate);
-        if (widevine::Cdm::kSuccess == _cdm->setServiceCertificate(widevine::Cdm::kAllServices, serverCertificate)) {
+
+        _adminLock.Lock();
+        if (widevine::Cdm::kSuccess == _cdm->setServiceCertificate(widevine::Cdm::ServiceRole::kAllServices, serverCertificate)) {
             dr = CDMi_SUCCESS;
+#if defined(DEBUG)
+	    cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] setServiceCertificate SUCCESS..!" << endl;
+#endif
+        }
+        _adminLock.Unlock();
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] result: " << dr << endl;
+	EXT_WV;
+#endif
+        return dr;
+    }
+
+    virtual CDMi_RESULT Metrics(uint32_t& bufferLength, uint8_t buffer[]) const {
+
+        CDMi_RESULT dr = CDMi_S_FALSE;
+        std::string metrics;
+        uint8_t* data;
+
+        if (widevine::Cdm::kSuccess == _cdm->getMetrics(&metrics)) {
+
+            dr = CDMi_SUCCESS;
+
+            bufferLength = metrics.size();
+
+            data = reinterpret_cast<uint8_t*>(const_cast<char*>(metrics.data()));
+            buffer = data;
+
+#if defined(DEBUG)
+
+            cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] GetMetrics SUCCESS..!" <<endl;
+
+#endif
+
         }
         return dr;
+
     }
 
     virtual CDMi_RESULT DestroyMediaKeySession(
         IMediaKeySession *f_piMediaKeySession) {
 
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         std::string sessionId (f_piMediaKeySession->GetSessionId());
 
         _adminLock.Lock();
@@ -248,13 +349,20 @@ public:
         SessionMap::iterator index (_sessions.find(sessionId));
 
         if (index != _sessions.end()) {
+            index->second->Close();
             _sessions.erase(index);
         }
 
         _adminLock.Unlock();
 
+#if defined(DEBUG)
+	cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] deleting MediaKeySession..!" << endl;
+#endif
         delete f_piMediaKeySession;
 
+#if defined(DEBUG)
+	EXT_WV;
+#endif
         return CDMi_SUCCESS;
     }
 
@@ -266,23 +374,51 @@ public:
 
         SessionMap::iterator index (_sessions.find(session_id));
 
-        if (index != _sessions.end()) index->second->onMessage(f_messageType, f_message);
+        if (index != _sessions.end()) { 
+ 	    index->second->onMessage(f_messageType, f_message);
+	}
 
         _adminLock.Unlock();
+
     }
 
-    virtual void onKeyStatusesChange(const std::string& /*session_id*/, bool /*has_new_usable_key*/) {
+    virtual void onKeyStatusesChange(const std::string& session_id, bool has_new_usable_key) {
+#if defined(DEBUG)
+	ENT_WV;
+#endif
+       _adminLock.Lock();
+
+        SessionMap::iterator index (_sessions.find(session_id));
+
+        if (index != _sessions.end()) {
+             index->second->onKeyStatusChange();
+        }
+
+        _adminLock.Unlock();
+
+#if defined(DEBUG)
+	EXT_WV;
+#endif
+
     }
 
     virtual void onRemoveComplete(const std::string& session_id) {
 
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         _adminLock.Lock();
 
         SessionMap::iterator index (_sessions.find(session_id));
 
-        if (index != _sessions.end()) index->second->onRemoveComplete();
+        if (index != _sessions.end()) {
+	    index->second->onRemoveComplete();
+	}
 
         _adminLock.Unlock();
+#if defined(DEBUG)
+	EXT_WV;
+#endif
     }
 
     // Called when a deferred action has completed.
@@ -292,7 +428,9 @@ public:
 
         SessionMap::iterator index (_sessions.find(session_id));
 
-        if (index != _sessions.end()) index->second->onDeferredComplete(result);
+        if (index != _sessions.end()) { 
+	    index->second->onDeferredComplete(result);
+	}
 
         _adminLock.Unlock();
     }
@@ -300,17 +438,41 @@ public:
     // Called when the CDM requires a new device certificate
     virtual void onDirectIndividualizationRequest(const std::string& session_id, const std::string& request) {
 
+#if defined(DEBUG)
+	ENT_WV;
+#endif
         _adminLock.Lock();
 
         SessionMap::iterator index (_sessions.find(session_id));
 
-        if (index != _sessions.end()) index->second->onDirectIndividualizationRequest(request);
+        if (index != _sessions.end()) {
+	    index->second->onDirectIndividualizationRequest(request);
+	}
 
+#if defined(DEBUG)
+	EXT_WV;
+#endif
         _adminLock.Unlock();
     }
 
+    virtual CDMi_RESULT GetMetrics(std::string& metrics) {
+        CDMi_RESULT dr = CDMi_S_FALSE;
+#if defined(DEBUG)
+	ENT_WV;
+#endif
+        _adminLock.Lock();
+        if (widevine::Cdm::kSuccess == _cdm->getMetrics(&metrics)) {
+            dr = CDMi_SUCCESS;
+        }
+        _adminLock.Unlock();
+#if defined(DEBUG)
+	EXT_WV;
+#endif
+        return dr;
+    }
+
 private:
-    Thunder::Core::CriticalSection _adminLock;
+    WPEFramework::Core::CriticalSection _adminLock;
     widevine::Cdm* _cdm;
     HostImplementation _host;
     SessionMap _sessions;
@@ -324,5 +486,9 @@ static SystemFactoryType<WideVine> g_instance({"video/webm", "video/mp4", "audio
 
 CDMi::ISystemFactory* GetSystemFactory() {
 
+#if defined(DEBUG)
+    ENT_WV;
+    EXT_WV;
+#endif
     return (&CDMi::g_instance); 
 }

--- a/Policy.h
+++ b/Policy.h
@@ -20,6 +20,7 @@
 
 using namespace wvcdm;
 
+#if defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED
 const std::string kDefaultServerCertificate = a2bs_hex(
     "0ABF020803121028703454C008F63618ADE7443DB6C4C8188BE7F99005228E023082010A02"
     "82010100B52112B8D05D023FCC5D95E2C251C1C649B4177CD8D2BEEF355BB06743DE661E3D"
@@ -41,9 +42,11 @@ const std::string kDefaultServerCertificate = a2bs_hex(
     "40383F9C5116D202A20C9229EE969C2519718303B50D0130C3352E06B014D838540F8A0C22"
     "7C0011E0F5B38E4E298ED2CB301EB4564965F55C5D79757A250A4EB9C84AB3E6539F6B6FDF"
     "56899EA29914");
+#endif /* defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED */
 
 const std::string kLicenseServer = "http://widevine-proxy.appspot.com/proxy";
 
+#if defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED
 const std::string kCencInitData = a2bs_hex(
     "00000042"                          // blob size
     "70737368"                          // "pssh"
@@ -54,3 +57,4 @@ const std::string kCencInitData = a2bs_hex(
     "08011a0d7769646576696e655f746573"
     "74220f73747265616d696e675f636c69"
     "7031");
+#endif /* defined WIDEVINE_DEFAULT_SERVER_CERTIFICATE_SUPPORTED */

--- a/cmake/FindWideVine.cmake
+++ b/cmake/FindWideVine.cmake
@@ -28,44 +28,11 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
 #
 
-find_path(WIDEVINE_INCLUDE_DIRS NAMES wv_cdm_types.h PATH_SUFFIXES "widevine")
+find_path (WIDEVINE_INCLUDE_DIRS NAME cdm.h PATHS "usr/include/" PATH_SUFFIXES "openssl")
 
-set(WV_LIBS  
-    widevine_ce_cdm_static 
-    ssl 
-    metrics_proto 
-    device_files 
-    oec_level3_static 
-    widevine_cdm_core 
-    license_protocol 
-    crypto
-)
-
-list(APPEND WIDEVINE_LIBRARIES "-Wl,--start-group")
-foreach(_library ${WV_LIBS})
-    message(STATUS "looking for ${_library}")
-    
-    find_library(_${_library}_location
-        NAME ${_library} 
-        PATH_SUFFIXES widevine
-    )
-    
-    list(APPEND WIDEVINE_LIBRARIES "${_${_library}_location}")
-endforeach()
-list(APPEND WIDEVINE_LIBRARIES "-Wl,--end-group")
-
-
-find_library(PROTO_BUF_LITE_LIBRARY NAME protobuf-lite PATH_SUFFIXES lib)
-list(APPEND WIDEVINE_LIBRARIES ${PROTO_BUF_LITE_LIBRARY})
-
-find_package(ThunderCore REQUIRED)
-find_package(CompileSettingsDebug REQUIRED)
-list(APPEND WIDEVINE_LIBRARIES ${NAMESPACE}Core::${NAMESPACE}Core)
-
-find_package(ClientDeviceInfo REQUIRED)
-list(APPEND WIDEVINE_LIBRARIES ClientDeviceInfo::ClientDeviceInfo)
+find_library(WIDEVINE_LIBRARIES NAME widevine_ce_cdm_shared PATH_SUFFIXES lib)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(Widevine DEFAULT_MSG WIDEVINE_INCLUDE_DIRS WIDEVINE_LIBRARIES)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(WIDEVINE DEFAULT_MSG WIDEVINE_INCLUDE_DIRS WIDEVINE_LIBRARIES)
 
 mark_as_advanced(WIDEVINE_INCLUDE_DIRS WIDEVINE_LIBRARIES)


### PR DESCRIPTION
We bring the revision: 7859f210f4fcd400da7c2db3c65cdaa4d28c61f7 from https://github.com/rdkcentral/OCDM-Widevine/commits/generic-mediasession/ branch.

This includes the below changes;
1. Common SVP (Secure Video Path) feature is supported
2. The new gst-svp-ext interface is used to move the SoC-specific changes from Mediasession. reference https://code.rdkcentral.com/r/plugins/gitiles/rdk/components/generic/gst_svp_ext
3. CMake changes are done to ensure the Compilation with the BRCM, Realtek & Amlogic platforms.
4. We are aligned with the Common rdk-adapter. Reference: https://github.com/rdkcentral/ThunderClientLibraries/blob/master/Source/ocdm/adapter/rdk/open_cdm_adapter.cpp