### PR TITLE
 RDKVREFPLT-5595: [RDKE][YT25] In Yts WidevineH264MultiMediaKeySessions test case, keycount is updated twice from ocdm-widevine

### DIFF
--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -386,16 +386,6 @@ public:
 #if defined(DEBUG)
 	ENT_WV;
 #endif
-       _adminLock.Lock();
-
-        SessionMap::iterator index (_sessions.find(session_id));
-
-        if (index != _sessions.end()) {
-             index->second->onKeyStatusChange();
-        }
-
-        _adminLock.Unlock();
-
 #if defined(DEBUG)
 	EXT_WV;
 #endif


### PR DESCRIPTION
Reason for change:
Modified the code to updated the onKeyStatusesChange() from license update call MediaKeySession::Update().

Test Procedure: Build and verify

Risks: None.

Signed-off-by: antonyxavier_francis@comcast.com