### PR TITLE
Fix for AMLS905X4-2226 & BCM-1591 Tickets.

### DIFF
--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -903,16 +903,22 @@ CDMi_RESULT MediaKeySession::Decrypt(
 #endif
 	    }
 
+#ifdef USE_SVP
+      if (useSVP) {
+        m_stSecureBuffInfo.bReleaseSecureMemRegion = false;
+        // Free decrypted secure buffer.
+        svp_release_secure_buffers(m_pSVPContext, (void*)&m_stSecureBuffInfo, nullptr, nullptr, 0);
+      }
+#endif
     }
   }
 
+ErrorExit:
   g_lock.Unlock();
 #if defined(DEBUG)
   cout << "\n[RDK_LOG:" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "] status: " << status << endl;
   EXT_WV;
 #endif
-
-ErrorExit:
   return status;
 }
 


### PR DESCRIPTION
**Reason for change:** AMLS905X4-2226 - Mutex unlock is missed during the failure case of the decrypt API, so added the mutex unlock to end of the API. BCM-1591 - In pre common ocdm broadcom code it seems memory was released after every decrypt, but in current code only if decrypt fails nexus memory block is released. 
**Test Procedure:** Build and verify
**Risks:** High.
**Signed-off-by:** sundaramuneeswaran_muthuraj@comcast.com