### PR TITLE
RDKMVE-2505: [BCM] WideVine initial playback fails in B1 devices

### DIFF
--- a/HostImplementation.cpp
+++ b/HostImplementation.cpp
@@ -201,7 +201,7 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
   // A specific name
   StorageMap::iterator it = _cache.find(name);
   if(it != _cache.end()) {
-      TRACE_L1("remove %s from cache", name);
+      TRACE_L1("remove %s from cache", name.c_str());
       _cache.erase(name);
   }
 

--- a/HostImplementation.cpp
+++ b/HostImplementation.cpp
@@ -90,7 +90,7 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
   TRACE_L1("name %s read from file", name.c_str());
   if(readFromeFile(name, data))
   {
-      TRACE_L1("name %s read and update cache %d", name.c_str(), data->size());
+      TRACE_L1("name %s read and update cache %zu", name.c_str(), data->size());
       _cache.emplace(name, std::string(reinterpret_cast<const char*>(data->data()), data->size()));
       return true;
   } else {
@@ -103,7 +103,7 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
   TRACE_L1("write: %s", name.c_str());
   _cache[name] = data;
   if(writeToFile(name, data)) {
-      TRACE_L1("sucess to write back %s.", name.c_str());
+      TRACE_L1("success to write back %s.", name.c_str());
       return true;
   } else {
       TRACE_L1("fail to write back %s!", name.c_str());
@@ -152,7 +152,7 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
   
   // When name contains a wild card
   if (name.find("*") != string::npos) {
-    TRACE_L1("remove %s with wildcard", name);
+    TRACE_L1("remove %s with wildcard", name.c_str());
     DIR *Directory = opendir(_basepath.c_str());
     if (Directory == NULL)
       return false;

--- a/HostImplementation.cpp
+++ b/HostImplementation.cpp
@@ -18,8 +18,12 @@
  */
 
 #include "HostImplementation.h"
-#include <fstream>
 
+#include <dirent.h>
+#include <fnmatch.h>
+#include <fstream>
+#include <sys/stat.h>
+#include <unistd.h>
 using namespace widevine;
 using namespace WPEFramework;
 
@@ -50,15 +54,30 @@ void HostImplementation::PreloadFile(const std::string& filename, std::string&& 
 }
 
 bool HostImplementation::readFromeFile(const std::string& name, std::string* data) {
-  struct stat Stat;
-  string filePath(_basepath + '/' + name);
-  if (stat(filePath.c_str(), &Stat) < 0)
+  if (data == nullptr) {
     return false;
-  
+  }
+
+  struct stat Stat;
+  const std::string filePath(_basepath + '/' + name);
+  if (stat(filePath.c_str(), &Stat) < 0) {
+    return false;
+  }
+
   std::ifstream File(filePath, std::ios::binary | std::ios::in);
-  data->resize(Stat.st_size);
-  File.read(&(*data)[0], data->size());
-  return true;
+  if (!File.is_open()) {
+    return false;
+  }
+
+  data->resize(static_cast<size_t>(Stat.st_size));
+  if (!data->empty()) {
+    File.read(&(*data)[0], data->size());
+    if (File.gcount() != static_cast<std::streamsize>(data->size())) {
+      return false;
+    }
+  }
+
+  return File.good();
 }
 
 bool HostImplementation::writeToFile(const std::string& name, const std::string& data) {
@@ -139,8 +158,12 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
         return false;
 
       struct dirent *Entry;
-      while (Entry = readdir(Directory), Entry != NULL) {
-        string filePath(_basepath + '/' + Entry->d_name);
+      while ((Entry = readdir(Directory)) != NULL) {
+        const std::string entryName(Entry->d_name);
+        if ((entryName == ".") || (entryName == "..")) {
+          continue;
+        }
+        std::string filePath(_basepath + '/' + Entry->d_name);
         TRACE_L1("remove %s", filePath.c_str());
         unlink(filePath.c_str());
       }
@@ -201,8 +224,8 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
     TRACE_L1("name %s not found", name.c_str());
     return -1;
   } else {
-    TRACE_L1("name %s found, size %d", name.c_str(), Stat.st_size);
-    return Stat.st_size;
+    TRACE_L1("name %s found, size %lld", name.c_str(), static_cast<long long>(Stat.st_size));
+    return static_cast<int32_t>(Stat.st_size);
   }
 }
 
@@ -213,7 +236,11 @@ bool HostImplementation::writeToFile(const std::string& name, const std::string&
 
   names->clear();
   struct dirent *Entry;
-  while (Entry = readdir(Directory), Entry != NULL) {
+  while ((Entry = readdir(Directory)) != NULL) {
+    const std::string entryName(Entry->d_name);
+    if ((entryName == ".") || (entryName == "..")) {
+      continue;
+    }
     TRACE_L1("name %s add to list", Entry->d_name);
     names->push_back(Entry->d_name);
   }

--- a/HostImplementation.cpp
+++ b/HostImplementation.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "HostImplementation.h"
+#include <fstream>
 
 using namespace widevine;
 using namespace WPEFramework;
@@ -32,37 +33,96 @@ HostImplementation::HostImplementation()
   , widevine::Cdm::ILogger()
 #endif
   , _timer(Core::Thread::DefaultStackSize(),  _T("widevine"))
-  , _files() {
+  , _basepath("")
+  , _cache() {
 }
 
 HostImplementation::~HostImplementation() {
 }
 
+void HostImplementation::SetBasePath(const std::string& basepath) {
+  TRACE_L1("basepath %s", basepath.c_str());
+  _basepath = basepath;
+}
+
 void HostImplementation::PreloadFile(const std::string& filename, std::string&& filecontent ) {
-  _files.emplace(filename, filecontent);
+  _cache.emplace(filename, filecontent);
+}
+
+bool HostImplementation::readFromeFile(const std::string& name, std::string* data) {
+  struct stat Stat;
+  string filePath(_basepath + '/' + name);
+  if (stat(filePath.c_str(), &Stat) < 0)
+    return false;
+  
+  std::ifstream File(filePath, std::ios::binary | std::ios::in);
+  data->resize(Stat.st_size);
+  File.read(&(*data)[0], data->size());
+  return true;
+}
+
+bool HostImplementation::writeToFile(const std::string& name, const std::string& data) {
+  string filePath(_basepath + '/' + name);
+  try
+  {
+    std::ofstream File(filePath, std::ios::binary | std::ios::out);
+    File.write(data.data(), data.size());
+    return true;
+  }
+  catch (...)
+  {
+    return false;
+  }
 }
 
 // widevine::Cdm::IStorage implementation
 // ---------------------------------------------------------------------------
 /* virtual */ bool HostImplementation::read(const std::string& name, std::string* data) {
-  StorageMap::iterator it = _files.find(name);
-  bool ok = it != _files.end();
-  TRACE_L1("read file: %s: %s", name.c_str(), ok ? "ok" : "fail");
-  if (!ok) return false;
-  *data = it->second;
-  return true;
+  StorageMap::iterator it = _cache.find(name);
+  bool ok = it != _cache.end();
+  TRACE_L1("read: %s: cache %s", name.c_str(), ok ? "ok" : "fail");
+  if (ok) {
+    TRACE_L1("name %s read from cache", name.c_str());
+    *data = it->second;
+    return true;
+  }
+
+  TRACE_L1("name %s read from file", name.c_str());
+  if(readFromeFile(name, data))
+  {
+      TRACE_L1("name %s read and update cache %d", name.c_str(), data->size());
+      _cache.emplace(name, std::string(reinterpret_cast<const char*>(data->data()), data->size()));
+      return true;
+  } else {
+      TRACE_L1("name %s not found!", name.c_str());
+      return false;
+  }
 }
 
 /* virtual */ bool HostImplementation::write(const std::string& name, const std::string& data) {
-  TRACE_L1("write file: %s", name.c_str());
-  _files[name] = data;
-  return true;
+  TRACE_L1("write: %s", name.c_str());
+  _cache[name] = data;
+  if(writeToFile(name, data)) {
+      TRACE_L1("sucess to write back %s.", name.c_str());
+      return true;
+  } else {
+      TRACE_L1("fail to write back %s!", name.c_str());
+      return false;
+  }
 }
 
 /* virtual */ bool HostImplementation::exists(const std::string& name) {
-  StorageMap::iterator it = _files.find(name);
-  bool ok = it != _files.end();
+  StorageMap::iterator it = _cache.find(name);
+  bool ok = it != _cache.end();
   TRACE_L1("exists? %s: %s", name.c_str(), ok ? "true" : "false");
+  if(ok) {
+    TRACE_L1("name %s cache hit", name.c_str());
+    return true;
+  }
+
+  string filePath(_basepath + '/' + name);
+  ok = access(filePath.c_str(), F_OK) == 0;
+  TRACE_L1("name %s cache miss, check file at %s, ok %d", name.c_str(), filePath.c_str(), ok);
   return ok;
 }
 
@@ -70,24 +130,95 @@ void HostImplementation::PreloadFile(const std::string& filename, std::string&& 
   TRACE_L1("remove: %s", name.c_str());
   if (name.empty()) {
     // If no name, delete all files (see DeviceFiles::DeleteAllFiles())
-    _files.clear();
-  } else {
-    _files.erase(name);
+    TRACE_L1("remove: all cache");
+    _cache.clear();
+
+    { // Remove all files under a base path
+      DIR *Directory = opendir(_basepath.c_str());
+      if (Directory == NULL)
+        return false;
+
+      struct dirent *Entry;
+      while (Entry = readdir(Directory), Entry != NULL) {
+        string filePath(_basepath + '/' + Entry->d_name);
+        TRACE_L1("remove %s", filePath.c_str());
+        unlink(filePath.c_str());
+      }
+
+      closedir(Directory);
+    }
+    return true;
   }
+  
+  // When name contains a wild card
+  if (name.find("*") != string::npos) {
+    TRACE_L1("remove %s with wildcard", name);
+    DIR *Directory = opendir(_basepath.c_str());
+    if (Directory == NULL)
+      return false;
+
+    struct dirent *Entry;
+    while (Entry = readdir(Directory), Entry != NULL) {
+      if (fnmatch(name.c_str(), Entry->d_name, 0) == 0) {
+        StorageMap::iterator it = _cache.find(Entry->d_name);
+        if(it != _cache.end()) {
+          TRACE_L1("remove %s from cache", Entry->d_name);
+          _cache.erase(Entry->d_name);
+        }
+        string filePath(_basepath + '/' + Entry->d_name);
+        TRACE_L1("remove %s", filePath.c_str());
+        unlink(filePath.c_str());
+      }
+    }
+
+    closedir(Directory);
+    return true;
+  }
+
+  // A specific name
+  StorageMap::iterator it = _cache.find(name);
+  if(it != _cache.end()) {
+      TRACE_L1("remove %s from cache", name);
+      _cache.erase(name);
+  }
+
+  string filePath(_basepath + '/' + name);
+  TRACE_L1("remove %s", filePath.c_str());
+  unlink(filePath.c_str());
   return true;
 }
 
 /* virtual */ int32_t HostImplementation::size(const std::string& name) {
-  StorageMap::iterator it = _files.find(name);
-  if (it == _files.end()) return -1;
-  return it->second.size();
+  StorageMap::iterator it = _cache.find(name);
+  if (it != _cache.end()) {
+    TRACE_L1("name %s cache hit, size %d", name.c_str(), it->second.size());
+    return it->second.size();
+  }
+
+  struct stat Stat;
+  string filePath(_basepath + '/' + name);
+  if (stat(filePath.c_str(), &Stat) < 0) {
+    TRACE_L1("name %s not found", name.c_str());
+    return -1;
+  } else {
+    TRACE_L1("name %s found, size %d", name.c_str(), Stat.st_size);
+    return Stat.st_size;
+  }
 }
 
 /* virtual */ bool HostImplementation::list(std::vector<std::string>* names) {
+  DIR *Directory = opendir(_basepath.c_str());
+  if (Directory == NULL)
+    return false;
+
   names->clear();
-  for (StorageMap::iterator it = _files.begin(); it != _files.end(); it++) {
-      names->push_back(it->first);
+  struct dirent *Entry;
+  while (Entry = readdir(Directory), Entry != NULL) {
+    TRACE_L1("name %s add to list", Entry->d_name);
+    names->push_back(Entry->d_name);
   }
+
+  closedir(Directory);
   return true;
 }
 

--- a/HostImplementation.h
+++ b/HostImplementation.h
@@ -90,7 +90,10 @@ public:
 public:
 
   // note this method is not thread safe regarding simultanious widevine::Cdm::IStorage callbacks, make sure they cannot be not active when calling this
-  void PreloadFile(const std::string& filename, std::string&& filecontent );
+  void PreloadFile(const std::string& filename, std::string&& filecontent); /* deprecated */
+  void SetBasePath(const std::string& basepath);
+  bool readFromeFile(const std::string& name, std::string* data);
+  bool writeToFile(const std::string& name, const std::string& data);
 
   //
   // widevine::Cdm::IStorage implementation
@@ -119,7 +122,8 @@ public:
 
 private:
   WPEFramework::Core::TimerType<Timer> _timer;
-  StorageMap _files;
+  StorageMap _cache;
+  string _basepath;
 };
 
 } // namespace CDMi

--- a/HostImplementation.h
+++ b/HostImplementation.h
@@ -123,7 +123,7 @@ public:
 private:
   WPEFramework::Core::TimerType<Timer> _timer;
   StorageMap _cache;
-  string _basepath;
+  std::string _basepath;
 };
 
 } // namespace CDMi

--- a/MediaSession.cpp
+++ b/MediaSession.cpp
@@ -122,6 +122,7 @@ MediaKeySession::MediaKeySession(widevine::Cdm *cdm, int32_t licenseType)
     , m_rpcID(0)
 #endif
 {
+  bool is_retry_provisioning = false;
 #if defined(DEBUG)  
   ENT_WV;
   cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tGoing to createSession with licenseType: " << m_licenseType << " and sessionId: " << m_sessionId.c_str() << endl;
@@ -152,6 +153,7 @@ MediaKeySession::MediaKeySession(widevine::Cdm *cdm, int32_t licenseType)
   // Below steps are to done for provisioning when you get the return error "kNeedsDeviceCertificate" (101)
   // from cdm->createSession() function call
   if(status == 101) {
+retry_provision:
 #if defined(DEBUG)
         cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "Session creation failed with error \"kNeedsDeviceCertificate\" (101)" << endl;
 #endif
@@ -185,6 +187,18 @@ MediaKeySession::MediaKeySession(widevine::Cdm *cdm, int32_t licenseType)
 #if defined(DEBUG)
         cout << "\n[RDK_LOG]" << __FILE__ << "(" << __LINE__ << ")" << __FUNCTION__ << "\tResult of createSession() is: " <<  status << endl;
 #endif
+        if(status != widevine::Cdm::kSuccess) {
+            cout << "createSession fail with %d" << status << endl;
+            if(status == 101) { // May retry
+                if(is_retry_provisioning) {
+                    cout << "createSession fail with %d " << status << "in the second attempt!" << endl;
+                } else {
+                    is_retry_provisioning = true;
+                    cout << "createSession fail with %d " << status << "in the first attempt, try again" << endl;
+                    goto retry_provision;
+                }
+            }
+        }
   }
 
   ::memset(m_IV, 0 , sizeof(m_IV));;

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -152,6 +152,19 @@ public:
         Config config;
         config.FromString(configline);
 
+        { // Set a base path for IStorage such as cert.bin and usgtable.bin
+            string basePath;
+            if( shell->PersistentPath().back() == '/' ) {
+                basePath = string(shell->PersistentPath() + "wv.storage");
+            } else {
+                basePath = string(shell->PersistentPath() + "/wv.storage");
+            }
+
+            TRACE_L1("BasePath %s\n", basePath.c_str());
+            Core::Directory(basePath.c_str()).CreatePath();
+            _host.SetBasePath(basePath);
+        }
+
         if (config.Product.IsSet() == true) {
             client_info.product_name = config.Product.Value();
         } else {
@@ -195,16 +208,6 @@ public:
 
         if (config.Keybox.IsSet() == true) {
             Core::SystemInfo::SetEnvironment("WIDEVINE_KEYBOX_PATH", config.Keybox.Value().c_str());
-        }
-
-        if (config.Certificate.IsSet() == true) {
-            Core::DataElementFile dataBuffer(config.Certificate.Value(), Core::File::USER_READ);
-
-            if(dataBuffer.IsValid() == false) {
-                TRACE_L1(_T("Failed to open %s"), config.Certificate.Value().c_str());
-            } else {
-                _host.PreloadFile(_certificateFilename,  std::string(reinterpret_cast<const char*>(dataBuffer.Buffer()), dataBuffer.Size()));
-            }
         }
 
         if (widevine::Cdm::kSuccess == widevine::Cdm::initialize(

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -153,12 +153,9 @@ public:
         config.FromString(configline);
 
         { // Set a base path for IStorage such as cert.bin and usgtable.bin
-            string basePath;
-            if( shell->PersistentPath().back() == '/' ) {
-                basePath = string(shell->PersistentPath() + "wv.storage");
-            } else {
-                basePath = string(shell->PersistentPath() + "/wv.storage");
-            }
+            const string persistentPath = shell->PersistentPath();
+            const bool hasTrailingSlash = (!persistentPath.empty() && (persistentPath.back() == '/'));
+            basePath = persistentPath + (hasTrailingSlash ? "wv.storage" : "/wv.storage");
 
             TRACE_L1("BasePath %s\n", basePath.c_str());
             Core::Directory(basePath.c_str()).CreatePath();

--- a/MediaSystem.cpp
+++ b/MediaSystem.cpp
@@ -155,9 +155,9 @@ public:
         { // Set a base path for IStorage such as cert.bin and usgtable.bin
             const string persistentPath = shell->PersistentPath();
             const bool hasTrailingSlash = (!persistentPath.empty() && (persistentPath.back() == '/'));
-            basePath = persistentPath + (hasTrailingSlash ? "wv.storage" : "/wv.storage");
+            const string basePath = persistentPath + (hasTrailingSlash ? "wv.storage" : "/wv.storage");
 
-            TRACE_L1("BasePath %s\n", basePath.c_str());
+            TRACE_L1("BasePath %s", basePath.c_str());
             Core::Directory(basePath.c_str()).CreatePath();
             _host.SetBasePath(basePath);
         }


### PR DESCRIPTION
Reason for change: fix for WideVine initial playback fail in BCM

Test Procedure: Build and verify.

Signed-off-by: ligin_punoose@comcast.com